### PR TITLE
fix: update ValueResponse to use user field from /value endpoint

### DIFF
--- a/src/polymarket_apis/types/data_types.py
+++ b/src/polymarket_apis/types/data_types.py
@@ -172,7 +172,7 @@ class HolderResponse(BaseModel):
 
 class ValueResponse(BaseModel):
     # User identification
-    user: EthAddress = Field(alias="user")
+    user: EthAddress
 
     # Value information
     value: float


### PR DESCRIPTION
## Summary

Fixes a schema mismatch in the `/value` endpoint response. The API returns a `user` field, but `ValueResponse` previously expected `proxyWallet`, which caused a runtime ValidationError when calling:
```{python}
from polymarket_apis import PolymarketDataClient
data_client = PolymarketDataClient()
data_client.get_value(user=...)
```
Resulting:
```{bash}
ValidationError: 1 validation error for ValueResponse
proxyWallet
  Field required [type=missing, input_value={'user': '...', 'value': ...}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```

## Change

Update `ValueResponse` to match the actual response:
```{python}
class ValueResponse(BaseModel):
    user: EthAddress
    value: float
```

## Testing

Manually verified that parses successfully without validation errors.
