### PR TITLE
chore: remove unused wsaccel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "httpx[http2]>=0.25.1",
     "web3>=7.0",
     "lomond>=0.3.3",
-    "wsaccel>=0.6.7",
     "gql[httpx]>=4.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.3"
+version = "7.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-server" },
@@ -1964,9 +1964,9 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/cb/cc7f4df5cee315dd126a47eb60890690a0438d5e0dd40c32d60ce16de377/notebook-7.5.3.tar.gz", hash = "sha256:393ceb269cf9fdb02a3be607a57d7bd5c2c14604f1818a17dbeb38e04f98cbfa", size = 14073140, upload-time = "2026-01-26T07:28:36.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/08/9d446fbb49f95de316ea6d7f25d0a4bc95117dd574e35f405895ac706f29/notebook-7.5.4.tar.gz", hash = "sha256:b928b2ba22cb63aa83df2e0e76fe3697950a0c1c4a41b84ebccf1972b1bb5771", size = 14167892, upload-time = "2026-02-24T14:13:56.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/98/9286e7f35e5584ebb79f997f2fb0cb66745c86f6c5fccf15ba32aac5e908/notebook-7.5.3-py3-none-any.whl", hash = "sha256:c997bfa1a2a9eb58c9bbb7e77d50428befb1033dd6f02c482922e96851d67354", size = 14481744, upload-time = "2026-01-26T07:28:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/59/01/05e5387b53e0f549212d5eff58845886f3827617b5c9409c966ddc07cb6d/notebook-7.5.4-py3-none-any.whl", hash = "sha256:860e31782b3d3a25ca0819ff039f5cf77845d1bf30c78ef9528b88b25e0a9850", size = 14578014, upload-time = "2026-02-24T14:13:52.274Z" },
 ]
 
 [[package]]
@@ -2114,7 +2114,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "web3" },
-    { name = "wsaccel" },
 ]
 
 [package.dev-dependencies]
@@ -2149,7 +2148,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "web3", specifier = ">=7.0" },
-    { name = "wsaccel", specifier = ">=0.6.7" },
 ]
 
 [package.metadata.requires-dev]
@@ -3265,34 +3263,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
-]
-
-[[package]]
-name = "wsaccel"
-version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/06/e8f0450952ed1fb4aa2033a30ae5afb59632f5a35d441bcc6801a3aaca47/wsaccel-0.6.7.tar.gz", hash = "sha256:aea79ba46b1a3792dbd1fe364aeb8a10128659c67057770c5c320d1f58588a8c", size = 290942, upload-time = "2024-10-10T17:50:09.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ff/da5cc16c71b14c001437187b8ec9e3aa573e3ab759d3fd754686ebb4094d/wsaccel-0.6.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:acb1a589c82e09581996d04b484af9ca85b220df59c5d8670d02684e9c60175b", size = 614593, upload-time = "2024-10-10T17:49:23.099Z" },
-    { url = "https://files.pythonhosted.org/packages/07/4b/e20e7d9108f9e96af8f011a338841fbd0c70406958f35337ddd2a0852934/wsaccel-0.6.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7aeced9ee6febd28196baf4d5cbb12390c70ae14bb069d77b53defb01fa53ea", size = 1272974, upload-time = "2024-10-10T17:49:24.276Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/20/4e272e6f41c6b4b301cd9e3f2adbae406315abbd9357d9feb22f6da58fde/wsaccel-0.6.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdd4425424620d77d008fab0d1535bb715cc23db099b6aa0622d6958e0be0a54", size = 1287826, upload-time = "2024-10-10T17:49:25.65Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b5/e4e831372800a9e50bc1f80ad8a7a0c454ec0493d2de3bd04d5fd84eb7f2/wsaccel-0.6.7-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:afb1117f082c46404090b9ac5857a59fc47daa0016618244ec8581c3474e2e57", size = 1234433, upload-time = "2024-10-10T17:49:27.217Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/43/403c6f7759ec2fb42b4b17317ac10c0407a7308786df740fda7391e9068a/wsaccel-0.6.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4a8bc3771ee4d96743531352cc87c9c2c089889a4a63cedc26118500c3886153", size = 1287002, upload-time = "2024-10-10T17:49:29.267Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/32/75024bd053a8ed79102f44c0cd46f8352d195a41ca9b8495e69b4b5d8f97/wsaccel-0.6.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:1e5f67e7cd37a9d20db7ffd926a87b628989ca077a3b5219662f710c4d97671d", size = 1278172, upload-time = "2024-10-10T17:49:30.68Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a8/de7e5218f5c0ee5ed2c582f55fbfb34e471dd4eb0bc296e7d4ee9072a3ef/wsaccel-0.6.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2cddde2eecf410790dc1b0e980b690397e02f29042166d4a88ca684ebf58b3ab", size = 1327301, upload-time = "2024-10-10T17:49:34.413Z" },
-    { url = "https://files.pythonhosted.org/packages/94/6a/d9a42ce04f43d7e0e5ee3518a6bc94f347aaf87c5e46a295c5a3ca37c96a/wsaccel-0.6.7-cp312-cp312-win32.whl", hash = "sha256:acab8bd803a4c14ab8eb5f26d89cbf06d643f1e8331105b41d5520902f6a39cc", size = 420319, upload-time = "2024-10-10T17:49:35.767Z" },
-    { url = "https://files.pythonhosted.org/packages/85/78/bcc23ec5ee2f3345a9d507a9f242188846b729792f8f8d7be610f5ca2a54/wsaccel-0.6.7-cp312-cp312-win_amd64.whl", hash = "sha256:a03fca13165c1f9a0cb5dee7c5555fdb9f8a163fd55d6f0c4c9dd9f9dabd568a", size = 445467, upload-time = "2024-10-10T17:49:37.085Z" },
-    { url = "https://files.pythonhosted.org/packages/94/69/3a8d3607688688b7a93b17d2a1367d9427436071ef0eb340437a472b09dd/wsaccel-0.6.7-cp312-cp312-win_arm64.whl", hash = "sha256:e26a76ab356ed79c3f29b9a5f227b7e7ecc96863c3b62a084194a2e9b4d5af6c", size = 415733, upload-time = "2024-10-10T17:49:38.325Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/51/59413912dcdb7000568cd3aa2196c77bd11ab78cd2ded2516ccbb4b2d793/wsaccel-0.6.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e464f0dc792af666411d36b575b26c87ad7f64aab882384d40c8ad8f146e192d", size = 610057, upload-time = "2024-10-10T17:49:39.972Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/45/4bf88f0fdfb9337a397c9bb5de8bd7506a1a64758c12df8c0750adcb8d0f/wsaccel-0.6.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0be143f69b498015490f6b3c5f1ff128736554a0cd13e97884cc8e4e347abafd", size = 1258005, upload-time = "2024-10-10T17:49:41.722Z" },
-    { url = "https://files.pythonhosted.org/packages/95/57/6117dea1354a3f749abd72f1478f81f5e9ada8810f8ca32d08dc45c4999b/wsaccel-0.6.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:052587b4d01ce0615dc33c72b1bc986c704fa2b342612cb97c898a9fba0520b4", size = 1272523, upload-time = "2024-10-10T17:49:43.585Z" },
-    { url = "https://files.pythonhosted.org/packages/38/d2/6de48bbabb29c38a5e21aabfd91ce9070a2c21df2f05fe8164662f22a3c8/wsaccel-0.6.7-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c1870b9a65d5216f6bc66f1b529211d385ef2186f9560e5b7dc15be86fc36f62", size = 1216390, upload-time = "2024-10-10T17:49:44.912Z" },
-    { url = "https://files.pythonhosted.org/packages/02/48/6ff74d6a2a8da7c156a3256bd2efad89bc4ec59d7195d59e3eb39fe0075d/wsaccel-0.6.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2816d09a24198c84d3cbf20cd180587538fb396a4fe5278bad8e39750464bf37", size = 1275559, upload-time = "2024-10-10T17:49:46.761Z" },
-    { url = "https://files.pythonhosted.org/packages/30/3e/c1fa56d4c7463f0623e4db950065217367eec0967cb31dd5475d9aab7f93/wsaccel-0.6.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6158d16a0c06b86288b866d4a04511011bac2533d9f91f7ed40f904a228bf875", size = 1268623, upload-time = "2024-10-10T17:49:48.262Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/2d/479b3b7c42ca0eeb0d8a6466e3a9f518b028fa7c8cd9b41fe410f4c38d87/wsaccel-0.6.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:014e454d18941a11c583ad8f9d4c1bc3a6a7fdccae31b5090124122396383df9", size = 1318390, upload-time = "2024-10-10T17:49:49.72Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/73/ada00ffb20068b52c8cc3712c99ba018f3e36a6ca32c55eb2904f81080e1/wsaccel-0.6.7-cp313-cp313-win32.whl", hash = "sha256:024be44fcc651b9da44dea9ebb3f91d341e0b89f6a52d1ddfe98b6b54be2bcc5", size = 420318, upload-time = "2024-10-10T17:49:51.027Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d7/5655ba6a7ca19abec9117faf667de5aa300123d8985d0785afa5857e2642/wsaccel-0.6.7-cp313-cp313-win_amd64.whl", hash = "sha256:4711238618840a25969514665dc83694b0aa76d7ea4dd39fb8879ea0e60a465e", size = 445156, upload-time = "2024-10-10T17:49:52.338Z" },
-    { url = "https://files.pythonhosted.org/packages/70/a6/3c0c33455a6e01ffb839ca253040fefc02dfd0a82f89342d2b7a11774520/wsaccel-0.6.7-cp313-cp313-win_arm64.whl", hash = "sha256:7223090fc11e47950e9aa888281102483ad3a3f7a872c0d914e8bfc775da625e", size = 415643, upload-time = "2024-10-10T17:49:53.784Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Drop `wsaccel` as it was not used in the code, and it was breaking build for free-threaded python.