### PR TITLE
Extend Last trade price model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polymarket-apis"
-version = "0.5.1"
+version = "0.5.2"
 description = "Unified Polymarket APIs with Pydantic data validation - Clob, Gamma, Data, Web3, Websockets, GraphQL clients."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/polymarket_apis/types/websockets_types.py
+++ b/src/polymarket_apis/types/websockets_types.py
@@ -42,6 +42,7 @@ class LastTradePrice(BaseModel):
     token_id: str = Field(alias="asset_id")
     condition_id: Keccak256 = Field(alias="market")
     fee_rate_bps: float
+    transaction_hash: Keccak256 | None = Field(default=None)
 
 
 class OrderBookSummaryEvent(OrderBookSummary):

--- a/src/polymarket_apis/types/websockets_types.py
+++ b/src/polymarket_apis/types/websockets_types.py
@@ -41,7 +41,7 @@ class LastTradePrice(BaseModel):
     side: Literal["BUY", "SELL"]
     token_id: str = Field(alias="asset_id")
     condition_id: Keccak256 = Field(alias="market")
-    fee_rate_bps: float | None = Field(default=None)
+    fee_rate_bps: float
     transaction_hash: Keccak256 | None = Field(default=None)
 
 

--- a/src/polymarket_apis/types/websockets_types.py
+++ b/src/polymarket_apis/types/websockets_types.py
@@ -41,7 +41,7 @@ class LastTradePrice(BaseModel):
     side: Literal["BUY", "SELL"]
     token_id: str = Field(alias="asset_id")
     condition_id: Keccak256 = Field(alias="market")
-    fee_rate_bps: float
+    fee_rate_bps: float | None = Field(default=None)
     transaction_hash: Keccak256 | None = Field(default=None)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2138,7 +2138,7 @@ wheels = [
 
 [[package]]
 name = "polymarket-apis"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "gql", extra = ["httpx"] },


### PR DESCRIPTION
Changelog:

- Fix https://github.com/qualiaenjoyer/polymarket-apis/issues/42
- Made `fee_rate_bps` nullable in accordance with the official documents of the Polymarket API.